### PR TITLE
Fix "Cannot find module './typeset'" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const applyTypeset = require('./typeset');
+const applyTypeset = require('./typeset-plugin');
 
 module.exports = (options) => (eleventyConfig, pluginNamespace) => {
   eleventyConfig.namespace(pluginNamespace, () => {


### PR DESCRIPTION
Looks like file was renamed, but reference to it was forgotten and wasn't changed. This PR includes a change to the `require(...)` line and fixes this issue.